### PR TITLE
use pinned libxml2

### DIFF
--- a/.ci_support/linux_64_r_base4.1.yaml
+++ b/.ci_support/linux_64_r_base4.1.yaml
@@ -12,6 +12,8 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libxml2:
+- '2.9'
 pin_run_as_build:
   r-base:
     min_pin: x.x

--- a/.ci_support/linux_64_r_base4.2.yaml
+++ b/.ci_support/linux_64_r_base4.2.yaml
@@ -12,6 +12,8 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libxml2:
+- '2.9'
 pin_run_as_build:
   r-base:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_r_base4.1.yaml
+++ b/.ci_support/linux_aarch64_r_base4.1.yaml
@@ -16,6 +16,8 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
+libxml2:
+- '2.9'
 pin_run_as_build:
   r-base:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_r_base4.2.yaml
+++ b/.ci_support/linux_aarch64_r_base4.2.yaml
@@ -16,6 +16,8 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
+libxml2:
+- '2.9'
 pin_run_as_build:
   r-base:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_r_base4.1.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.1.yaml
@@ -12,6 +12,8 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
+libxml2:
+- '2.9'
 pin_run_as_build:
   r-base:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_r_base4.2.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.2.yaml
@@ -12,6 +12,8 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
+libxml2:
+- '2.9'
 pin_run_as_build:
   r-base:
     min_pin: x.x

--- a/.ci_support/osx_64_r_base4.1.yaml
+++ b/.ci_support/osx_64_r_base4.1.yaml
@@ -10,6 +10,8 @@ channel_targets:
 - conda-forge main
 cran_mirror:
 - https://cran.r-project.org
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_r_base4.2.yaml
+++ b/.ci_support/osx_64_r_base4.2.yaml
@@ -10,6 +10,8 @@ channel_targets:
 - conda-forge main
 cran_mirror:
 - https://cran.r-project.org
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 1
+  number: 2
   skip: true  # [r_base == "3.6" or win]
   rpaths:
     - lib/R/lib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,11 @@ requirements:
     - {{ posix }}zip               # [win]
   host:
     - r-base
-    - libxml2 >=2.6.3
+    - libxml2
 
   run:
     - r-base
-    - libxml2 >=2.6.3
+    - libxml2
     - {{ native }}gcc-libs         # [win]
 
 test:


### PR DESCRIPTION
Explicit lower bound appears to be overriding global pinning of `libxml2`, resulting in builds that couldn't co-install with other packages. E.g., this should enable solving for:

* https://github.com/conda-forge/r-rgexf-feedstock/pull/10
* https://github.com/conda-forge/r-rnexml-feedstock/pull/8

# Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
